### PR TITLE
improvement: Add cross tests for easier testing

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticTokenProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticTokenProvider.scala
@@ -1,26 +1,21 @@
 package scala.meta.internal.pc
-import java.util
-import java.util.logging.Logger
 import java.{util => ju}
 
 import scala.collection.mutable.ListBuffer
-import scala.reflect.internal.util.Position
 
 import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.pc.SemanticTokenCapability._
 import scala.meta.pc.VirtualFileParams
 import scala.meta.tokens._
-import scala.meta.internal.pc.SemanticTokenCapability._
-import org.checkerframework.common.returnsreceiver.qual.This
+
 import org.eclipse.lsp4j.SemanticTokenModifiers
 import org.eclipse.lsp4j.SemanticTokenTypes
-import scala.meta.pc.DefinitionResult
 
 /**
  * Corresponds to tests.SemanticHighlightLspSuite
  */
 final class SemanticTokenProvider(
-    protected val cp: MetalsGlobal // compiler
-    ,
+    protected val cp: MetalsGlobal, // compiler
     val params: VirtualFileParams
 ) {
   val capableTypes = TokenTypes

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -85,9 +85,7 @@ case class ScalaPresentationCompiler(
     new MetalsDriver(settings)
 
   override def semanticTokens(
-      params: VirtualFileParams,
-      capableTypes: java.util.List[String],
-      capableModifiers: java.util.List[String],
+      params: VirtualFileParams
   ): CompletableFuture[ju.List[Integer]] =
     CompletableFuture.completedFuture {
       new ju.ArrayList[Integer]()

--- a/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
+++ b/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
@@ -1,0 +1,54 @@
+package tests.tokens
+
+import tests.BasePCSuite
+import munit.TestOptions
+import munit.Location
+import scala.meta.internal.metals.CompilerVirtualFileParams
+import scala.meta.internal.jdk.CollectionConverters._
+import java.net.URI
+import tests.TestSemanticTokens
+
+class SemanticTokensSuite extends BasePCSuite {
+
+  check(
+    "deprecated",
+    s"""|<<object>>/*keyword*/ <<sample9>>/*class*/ {
+        |  <<@>>/*keyword*/<<deprecated>>/*class*/(<<"this method will be removed">>/*string*/, <<"FooLib 12.0">>/*string*/)
+        |  <<def>>/*keyword*/ <<oldMethod>>/*method,deprecated*/(<<x>>/*parameter*/: <<Int>>/*class,abstract*/) = <<x>>/*parameter*/
+        |
+        |  <<def>>/*keyword*/ <<main>>/*method*/(<<args>>/*parameter*/: <<Array>>/*class*/[String]) ={
+        |    <<val>>/*keyword*/ <<str>>/*variable,readonly*/ = <<oldMethod>>/*method,deprecated*/(<<2>>/*number*/).<<toString>>/*method*/
+        |     <<println>>/*method*/(<<"Hello, world!">>/*string*/<<+>>/*method*/ <<str>>/*variable,readonly*/)
+        |  }
+        |}
+        |""".stripMargin,
+  )
+
+  def check(
+      name: TestOptions,
+      expected: String,
+  )(implicit location: Location): Unit =
+    test(name) {
+
+      val base =
+        expected
+          .replaceAll(raw"/\*[\w,]+\*/", "")
+          .replaceAll(raw"\<\<|\>\>", "")
+
+      val tokens = presentationCompiler
+        .semanticTokens(
+          CompilerVirtualFileParams(URI.create("file:/Tokens.scala"), base)
+        )
+        .get()
+
+      val obtained = TestSemanticTokens.semanticString(
+        base,
+        tokens.asScala.toList.map(_.toInt),
+      )
+      assertEquals(
+        obtained,
+        expected,
+      )
+
+    }
+}

--- a/tests/mtest/src/main/scala/tests/TestSemanticTokens.scala
+++ b/tests/mtest/src/main/scala/tests/TestSemanticTokens.scala
@@ -1,0 +1,96 @@
+package tests
+
+import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
+
+import scala.meta.internal.metals.TextEdits
+import scala.meta.internal.pc.SemanticTokenCapability._
+
+import org.eclipse.{lsp4j => l}
+
+object TestSemanticTokens {
+
+  def semanticString(fileContent: String, obtainedTokens: List[Int]) = {
+
+    /**
+     * construct string from token type and mods to decorate codes.
+     */
+    def decorationString(typeInd: Int, modInd: Int): String = {
+      val buffer = ListBuffer.empty[String]
+
+      // TokenType
+      if (typeInd != -1) {
+        buffer.addAll(List(TokenTypes(typeInd)))
+      }
+
+      // TokenModifier
+      // wkList = (e.g.) modInd=32 -> 100000 -> "000001"
+      val wkList = modInd.toBinaryString.toCharArray().toList.reverse
+      for (i: Int <- 0 to wkList.size - 1) {
+        if (wkList(i).toString == "1") {
+          buffer.addAll(
+            List(
+              TokenModifiers(i)
+            )
+          )
+        }
+      }
+
+      // return
+      buffer.toList.mkString(",")
+    }
+
+    val allTokens = obtainedTokens
+      .grouped(5)
+      .map(_.toList)
+      .map {
+        case List(
+              deltaLine,
+              deltaStartChar,
+              length,
+              tokenType,
+              tokenModifier,
+            ) => // modifiers ignored for now
+          (
+            new l.Position(deltaLine, deltaStartChar),
+            length,
+            decorationString(tokenType, tokenModifier),
+          )
+        case _ =>
+          throw new RuntimeException("Expected output dividable by 5")
+      }
+      .toList
+
+    @tailrec
+    def toAbsolutePositions(
+        positions: List[(l.Position, Int, String)],
+        last: l.Position,
+    ): Unit = {
+      positions match {
+        case (head, _, _) :: next =>
+          if (head.getLine() != 0)
+            head.setLine(last.getLine() + head.getLine())
+          else {
+            head.setLine(last.getLine())
+            head.setCharacter(
+              last.getCharacter() + head.getCharacter()
+            )
+          }
+          toAbsolutePositions(next, head)
+        case Nil =>
+      }
+    }
+    toAbsolutePositions(allTokens, new l.Position(0, 0))
+
+    // Build textEdits  e.g. which converts 'def'  to  '<<def>>/*keyword*/'
+    val edits = allTokens.map { case (pos, len, typ) =>
+      val startEdit = new l.TextEdit(new l.Range(pos, pos), "<<")
+      val end = new l.Position(pos.getLine(), pos.getCharacter() + len)
+      val endEdit = new l.TextEdit(new l.Range(end, end), s">>/*${typ}*/")
+      List(startEdit, endEdit)
+    }.flatten
+
+    TextEdits.applyEdits(fileContent, edits)
+
+  }
+}

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -60,7 +60,6 @@ import scala.meta.internal.metals.findfiles._
 import scala.meta.internal.metals.testProvider.BuildTargetUpdate
 import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.parsing.Trees
-import scala.meta.internal.pc.SemanticTokenCapability._
 import scala.meta.internal.semanticdb.Scala.Symbols
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.tvp.TreeViewChildrenParams
@@ -69,7 +68,6 @@ import scala.meta.internal.{semanticdb => s}
 import scala.meta.io.AbsolutePath
 import scala.meta.io.RelativePath
 
-import _root_.org.eclipse.lsp4j.DocumentSymbolCapabilities
 import ch.epfl.scala.{bsp4j => b}
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
@@ -94,6 +92,7 @@ import org.eclipse.lsp4j.DidSaveTextDocumentParams
 import org.eclipse.lsp4j.DocumentFormattingParams
 import org.eclipse.lsp4j.DocumentOnTypeFormattingParams
 import org.eclipse.lsp4j.DocumentRangeFormattingParams
+import org.eclipse.lsp4j.DocumentSymbolCapabilities
 import org.eclipse.lsp4j.DocumentSymbolParams
 import org.eclipse.lsp4j.ExecuteCommandParams
 import org.eclipse.lsp4j.FoldingRangeCapabilities
@@ -1284,129 +1283,22 @@ final case class TestingServer(
       expected: String,
       fileContent: String,
   ): Future[Unit] = {
-    try {
+    val uri = toPath(filePath).toTextDocumentIdentifier
+    val params = new org.eclipse.lsp4j.SemanticTokensParams(uri)
 
-      scribe.info("\n Debug:  assertSemanticHighlight: Start")
+    for {
+      obtainedTokens <- server.semanticTokensFull(params).asScala
+    } yield {
+      val obtained = TestSemanticTokens.semanticString(
+        fileContent,
+        obtainedTokens.getData().map(_.toInt).asScala.toList,
+      )
 
-      val uri = toPath(filePath).toTextDocumentIdentifier
-      val params = new org.eclipse.lsp4j.SemanticTokensParams(uri)
-
-      /**
-       * construct string from token type and mods to decorate codes.
-       */
-      def decorationString(typeInd: Int, modInd: Int): String = {
-        val buffer = ListBuffer.empty[String]
-
-        // TokenType
-        if (typeInd != -1) {
-          buffer.addAll(List(TokenTypes(typeInd)))
-        }
-
-        // TokenModifier
-        // wkList = (e.g.) modInd=32 -> 100000 -> "000001"
-        val wkList = modInd.toBinaryString.toCharArray().toList.reverse
-        for (i: Int <- 0 to wkList.size - 1) {
-          if (wkList(i).toString == "1") {
-            buffer.addAll(
-              List(
-                TokenModifiers(i)
-              )
-            )
-          }
-        }
-
-        // return
-        buffer.toList.mkString(",")
-      }
-
-      // Getting semantic tokens from testee function
-      for {
-        obtainedTokens <- server.semanticTokensFull(params).asScala
-      } yield {
-        scribe.info(
-          "\n\n obtainedToken:   \n"
-            + obtainedTokens.getData.asScala
-              .grouped(5)
-              .map(_.mkString(","))
-              .mkString("\n")
-        )
-        val all = obtainedTokens
-          .getData()
-          .asScala
-          .grouped(5)
-          .map(_.toList)
-          .map {
-            case List(
-                  deltaLine,
-                  deltaStartChar,
-                  length,
-                  tokenType,
-                  tokenModifier,
-                ) => // modifiers ignored for now
-              (
-                new l.Position(deltaLine, deltaStartChar),
-                length,
-                decorationString(tokenType, tokenModifier),
-              )
-            case _ =>
-              throw new RuntimeException("Expected output dvidable by 5")
-          }
-          .toList
-
-        def updatePositions_FromRelativeToAbolute(
-            positions: List[(l.Position, Integer, String)],
-            last: l.Position,
-        ): Unit = {
-          positions match {
-            case (head, _, _) :: next =>
-              if (head.getLine() != 0)
-                head.setLine(last.getLine() + head.getLine())
-              else {
-                head.setLine(last.getLine())
-                head.setCharacter(
-                  last.getCharacter() + head.getCharacter()
-                )
-              }
-              updatePositions_FromRelativeToAbolute(next, head)
-            case Nil =>
-          }
-        }
-        updatePositions_FromRelativeToAbolute(all, new l.Position(0, 0))
-
-        // Build textEdits  e.g. which converts 'def'  to  '<<def>>/*keyword*/'
-        val edits = all.map { case (pos, len, typ) =>
-          val startEdit = new l.TextEdit(new l.Range(pos, pos), "<<")
-          val end = new l.Position(pos.getLine(), pos.getCharacter() + len)
-          val endEdit = new l.TextEdit(new l.Range(end, end), s">>/*${typ}*/")
-          List(startEdit, endEdit)
-        }.flatten
-
-        // Decorate fileContent with textEdits
-        val obtained = TextEdits.applyEdits(fileContent, edits)
-
-        val strlog = s"""
-                        |***fileContent***
-                        |$fileContent
-                        |
-                        |***obtained***
-                        |$obtained
-                        |
-                        |***expected***
-                        |$expected
-                        |""".stripMargin
-        scribe.info(strlog)
-
-        Assertions.assertNoDiff(
-          obtained,
-          expected,
-        )
-      }
-    } catch {
-      case e: Exception =>
-        e.printStackTrace()
-        null
+      Assertions.assertNoDiff(
+        obtained,
+        expected,
+      )
     }
-
   }
 
   def assertHighlight(


### PR DESCRIPTION
Cross tests are faster than LSP ones, so we could leave the tests already in LSP suite and add much more cases to the cross suite.

These tests can be run using `sbt cross/testOnly tests.tokens.SemanticTokensSuite`